### PR TITLE
Fixed couple of Typographical Error

### DIFF
--- a/chap_GK.tex
+++ b/chap_GK.tex
@@ -299,7 +299,7 @@ $$
 
 The proof of this is in fact a nice exercise, and we give a few hints
 at the end of this section. 
-Let us with the proof of
+Let us begin with the proof of
 \autoref{lem:random-lc-det-nonzero}.
 
 \begin{proof}[Proof of \autoref{lem:random-lc-det-nonzero}]

--- a/chap_GK.tex
+++ b/chap_GK.tex
@@ -373,7 +373,7 @@ Show that
   Show that
   \begin{eqnarray*}
     \Pr_{A \in \F_q^{n\times n}}[\Perm(A) = 0] & \leq &  \frac{1}{q^n} + \frac{1}{q^{n-1}} + \cdots + \frac{1}{q}\\
-    & = & \frac{1}{q-1}.
+    & = & \frac{1}{q-1}\inparen{1-\frac{1}{q^n}}.
   \end{eqnarray*}
   \textcolor{gray}{Hint: Use Koutis' trick (\autoref{lem:random-lc-det-nonzero}).}
 \end{exercise}


### PR DESCRIPTION
Here are short justification of changes I'm proposing.
- The first change is there because of a missing word in that sentence.
- If we use sum of geometric series on \frac{1}{q^n} + \frac{1}{q^{n-1}} + \cdots + \frac{1}{q} we get \frac{1}{q-1}\inparen{1-\frac{1}{q^n}} and hence justifies the correction.