### PR TITLE
microtype increases the quality of spacing etc

### DIFF
--- a/fancymain.tex
+++ b/fancymain.tex
@@ -16,6 +16,7 @@
 \usepackage{thmtools,thm-restate}
 \usepackage{ccicons}
 \usepackage{setspace}
+\usepackage{microtype}
 \usepackage[colorlinks]{hyperref}
 
 \input{version}
@@ -39,9 +40,9 @@
 
 \DeclareFixedFont{\titlefont}{T1}{ppl}{b}{it}{0.5in}
 
-\makeatletter                       
-\def\printauthor{%                  
-    {\large \@author}}              
+\makeatletter
+\def\printauthor{%
+    {\large \@author}}
 \makeatother
 \author{%
     Ramprasad Saptharishi \\


### PR DESCRIPTION
microtype generally makes the text spacing a bit better.
This stackexchange post gives a reasonable explanation https://tex.stackexchange.com/a/82637
or he package introduction https://ctan.org/pkg/microtype in the documentation. The defaults should be sufficient.