### PR TITLE
Minor fix in definition of VNP

### DIFF
--- a/chap_intro.tex
+++ b/chap_intro.tex
@@ -24,7 +24,7 @@ In the seminal paper of \cite{v79}, Valiant defined two classes of polynomials w
 \begin{definition}
 The class $\VP$ is defined as the set of all polynomial $f(x_1,\dots, x_n)$ with $\deg(f) = n^{O(1)}$ that can be computed by an arithmetic circuit of size $s = n^{O(1)}$. 
 
-The class $\VNP$ is defined as the set of all polynomial $f(x_1,\dots, x_n)$ such that there exists a $g(x_1,\dots, x_n, y_1,\dots, y_m)$ with $m = n^{O(1)}$ such that
+The class $\VNP$ is defined as the set of all polynomial $f(x_1,\dots, x_n)$ such that there exists a $g(x_1,\dots, x_n, y_1,\dots, y_m) \in \VP$ with $m = n^{O(1)}$ such that
 \[
 f(x_1,\dots, x_n) \quad = \quad \sum_{y_1=0}^1\dots \sum_{y_m=0}^1 g(x_1,\dots, x_n, y_1,\dots, y_m).
 \]


### PR DESCRIPTION
Minor fix. The polynomial g in the definition of VNP must lie in VP, to capture the notion of explicitness.